### PR TITLE
FIX: Unable to query cpu load on hexacore machines

### DIFF
--- a/portal/src/main/java/es/inteco/rastreador2/management/ManagementThread.java
+++ b/portal/src/main/java/es/inteco/rastreador2/management/ManagementThread.java
@@ -20,6 +20,7 @@ import static es.inteco.common.Constants.CRAWLER_PROPERTIES;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import com.sun.management.OperatingSystemMXBean;
@@ -123,7 +124,7 @@ public class ManagementThread extends Thread {
 		BigDecimal systemTime = new BigDecimal(System.nanoTime());
 		BigDecimal processCpuTime = new BigDecimal(osMXBean.getProcessCpuTime());
 		BigDecimal cpuUsage = (processCpuTime.subtract(lastProcessCpuTime)).divide(systemTime.subtract(lastSystemTime), 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal(100)).setScale(2)
-				.divide(new BigDecimal(osMXBean.getAvailableProcessors()));
+				.divide(new BigDecimal(osMXBean.getAvailableProcessors()), 4, RoundingMode.HALF_UP);
 		lastSystemTime = systemTime;
 		lastProcessCpuTime = processCpuTime;
 		return cpuUsage;


### PR DESCRIPTION
* The algorithm used to calculate the cpu load uses a BigDecimal to divide 100
  with the number of cores on the machine. This fails with an ArithmeticException
  due to "Non-terminating decimal expansion; no exact representable decimal result."
  on six core machines (100/6 = 16.666666...) unless a rounding mode is specified.