### PR TITLE
Work around for SQL GROUP BY statements that fail on MySQL 5.7

### DIFF
--- a/portal/src/main/java/es/inteco/rastreador2/dao/cuentausuario/CuentaUsuarioDAO.java
+++ b/portal/src/main/java/es/inteco/rastreador2/dao/cuentausuario/CuentaUsuarioDAO.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
-* Copyright (C) 2012 INTECO, Instituto Nacional de Tecnologías de la Comunicación, 
+* Copyright (C) 2012 INTECO, Instituto Nacional de Tecnologías de la Comunicación,
 * This program is licensed and may be used, modified and redistributed under the terms
-* of the European Public License (EUPL), either version 1.2 or (at your option) any later 
+* of the European Public License (EUPL), either version 1.2 or (at your option) any later
 * version as soon as they are approved by the European Commission.
-* Unless required by applicable law or agreed to in writing, software distributed under the 
-* License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
-* ANY KIND, either express or implied. See the License for the specific language governing 
+* Unless required by applicable law or agreed to in writing, software distributed under the
+* License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+* ANY KIND, either express or implied. See the License for the specific language governing
 * permissions and more details.
-* You should have received a copy of the EUPL1.2 license along with this program; if not, 
+* You should have received a copy of the EUPL1.2 license along with this program; if not,
 * you may find it at http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32017D0863
 * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-* Modificaciones: MINHAFP (Ministerio de Hacienda y Función Pública) 
+* Modificaciones: MINHAFP (Ministerio de Hacienda y Función Pública)
 * Email: observ.accesibilidad@correo.gob.es
 ******************************************************************************/
 package es.inteco.rastreador2.dao.cuentausuario;
@@ -220,26 +220,25 @@ public final class CuentaUsuarioDAO {
 
     public static CargarCuentasUsuarioForm userList(Connection c, CargarCuentasUsuarioForm cargarCuentasUsuarioForm, int page) throws SQLException {
         final List<ListadoCuentasUsuario> userAccountList = new ArrayList<>();
-        final String query;
-        if (page == Constants.NO_PAGINACION) {
-            query = "SELECT DISTINCT(cc.nombre), l.lista, cc.id_cuenta, GROUP_CONCAT(DISTINCT(c.aplicacion)) AS cartuchos " +
-                    "FROM cuenta_cliente cc " +
-                    "JOIN cuenta_cliente_cartucho ccc ON (ccc.id_cuenta = cc.id_cuenta) " +
-                    "JOIN lista l ON (cc.dominio = l.id_lista)" +
-                    "JOIN cartucho c ON (ccc.id_cartucho = c.id_cartucho) GROUP BY cc.nombre ORDER BY cc.nombre";
-        } else {
-            query = "SELECT DISTINCT(cc.nombre), l.lista, cc.id_cuenta, GROUP_CONCAT(DISTINCT(c.aplicacion)) AS cartuchos " +
-                    "FROM cuenta_cliente cc " +
-                    "JOIN cuenta_cliente_cartucho ccc ON (ccc.id_cuenta = cc.id_cuenta) " +
-                    "JOIN lista l ON (cc.dominio = l.id_lista)" +
-                    "JOIN cartucho c ON (ccc.id_cartucho = c.id_cartucho) GROUP BY cc.nombre ORDER BY cc.nombre LIMIT ? OFFSET ?";
+
+        String query = "SELECT DISTINCT(cc.nombre), l.lista, cc.id_cuenta, GROUP_CONCAT(DISTINCT(c.aplicacion)) " +
+        "AS cartuchos " +
+        "FROM cuenta_cliente cc " +
+        "JOIN cuenta_cliente_cartucho ccc ON (ccc.id_cuenta = cc.id_cuenta) " +
+        "JOIN lista l ON (cc.dominio = l.id_lista)" +
+        "JOIN cartucho c ON (ccc.id_cartucho = c.id_cartucho) " +
+        "GROUP BY cc.nombre, l.lista, cc.id_cuenta ORDER BY cc.nombre";
+
+        if (page != Constants.NO_PAGINACION) {
+            query += " LIMIT ? OFFSET ?";
         }
+
         final PropertiesManager pmgr = new PropertiesManager();
-        final int pagSize = Integer.parseInt(pmgr.getValue(CRAWLER_PROPERTIES, "pagination.size"));
-        final int resultFrom = pagSize * page;
+        final int pageSize = Integer.parseInt(pmgr.getValue(CRAWLER_PROPERTIES, "pagination.size"));
+        final int resultFrom = pageSize * page;
         try (PreparedStatement ps = c.prepareStatement(query)) {
             if (page != Constants.NO_PAGINACION) {
-                ps.setInt(1, pagSize);
+                ps.setInt(1, pageSize);
                 ps.setInt(2, resultFrom);
             }
             try (ResultSet rs = ps.executeQuery()) {

--- a/portal/src/main/java/es/inteco/rastreador2/dao/login/LoginDAO.java
+++ b/portal/src/main/java/es/inteco/rastreador2/dao/login/LoginDAO.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
-* Copyright (C) 2012 INTECO, Instituto Nacional de Tecnologías de la Comunicación, 
+* Copyright (C) 2012 INTECO, Instituto Nacional de Tecnologías de la Comunicación,
 * This program is licensed and may be used, modified and redistributed under the terms
-* of the European Public License (EUPL), either version 1.2 or (at your option) any later 
+* of the European Public License (EUPL), either version 1.2 or (at your option) any later
 * version as soon as they are approved by the European Commission.
-* Unless required by applicable law or agreed to in writing, software distributed under the 
-* License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
-* ANY KIND, either express or implied. See the License for the specific language governing 
+* Unless required by applicable law or agreed to in writing, software distributed under the
+* License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+* ANY KIND, either express or implied. See the License for the specific language governing
 * permissions and more details.
-* You should have received a copy of the EUPL1.2 license along with this program; if not, 
+* You should have received a copy of the EUPL1.2 license along with this program; if not,
 * you may find it at http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32017D0863
 * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-* Modificaciones: MINHAFP (Ministerio de Hacienda y Función Pública) 
+* Modificaciones: MINHAFP (Ministerio de Hacienda y Función Pública)
 * Email: observ.accesibilidad@correo.gob.es
 ******************************************************************************/
 package es.inteco.rastreador2.dao.login;
@@ -230,7 +230,7 @@ public final class LoginDAO {
                 "LEFT JOIN usuario_cartucho uc ON (u.id_usuario = uc.id_usuario) " +
                 "LEFT JOIN cartucho c ON (c.id_cartucho = uc.id_cartucho) " +
                 "WHERE u.id_usuario != 1 " +
-                "GROUP BY u.usuario ORDER BY u.usuario LIMIT ? OFFSET ?")) {
+                "GROUP BY u.usuario, u.id_usuario, r.id_tipo ORDER BY u.usuario LIMIT ? OFFSET ?")) {
             ps.setInt(1, pagSize);
             ps.setInt(2, resultFrom);
             try (ResultSet rs = ps.executeQuery()) {


### PR DESCRIPTION
* Make GROUP BY more explicit to prevent "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column <column name> which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by" that pops up when running these SQL statements on MySQL 5.7.

NOTE: These changes have not been tested on pre 5.7 versions.

Sorry about the whitespace noise in the diff.