### PR TITLE
Remove references to dropped column lista.dependencia

### DIFF
--- a/portal/src/initial/java/es/inteco/rastreador2/export/ddbb/ExportObservatoryDDBB.java
+++ b/portal/src/initial/java/es/inteco/rastreador2/export/ddbb/ExportObservatoryDDBB.java
@@ -117,7 +117,7 @@ public class ExportObservatoryDDBB {
         bw.write("CREATE TABLE lista (id_lista bigint(20) NOT NULL auto_increment," +
                 "nombre varchar(255) NOT NULL,lista text NOT NULL," +
                 "id_categoria bigint(20) default NULL, acronimo varchar(25) default NULL," +
-                "dependencia varchar(255) default NULL, PRIMARY KEY (id_lista), " +
+                " PRIMARY KEY (id_lista), " +
                 "KEY id_categoria (id_categoria)," +
                 "FOREIGN KEY (id_categoria) REFERENCES categorias_lista (id_categoria) ON DELETE CASCADE) " +
                 "ENGINE=InnoDB;");
@@ -214,15 +214,9 @@ public class ExportObservatoryDDBB {
             String query = "INSERT INTO lista VALUES(" + rs.getString("id_lista") + ",'" + replaceSpecialChars(rs.getString("nombre")) + "','"
                     + rs.getString("lista") + "'," + rs.getString("id_categoria");
             if (rs.getString("acronimo") != null) {
-                query += ",'" + rs.getString("acronimo") + "',";
+                query += ",'" + rs.getString("acronimo") + "');";
             } else {
-                query += "," + rs.getString("acronimo") + ",";
-            }
-
-            if (rs.getString("dependencia") != null) {
-                query += " '" + rs.getString("dependencia") + "');";
-            } else {
-                query += rs.getString("dependencia") + ");";
+                query += "," + rs.getString("acronimo") + ");";
             }
 
             bw.write(query + "\n");

--- a/portal/src/main/java/es/inteco/rastreador2/action/cuentausuario/NuevaCuentaUsuarioAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/cuentausuario/NuevaCuentaUsuarioAction.java
@@ -99,21 +99,20 @@ public class NuevaCuentaUsuarioAction extends Action {
 								return mapping.findForward(Constants.VOLVER);
 							}
 							// Guardamos la semilla
-							SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaCuentaUsuarioForm.getNombre() + "-Semilla", nuevaCuentaUsuarioForm.getDominio(), null, null, null, null, null,
-									null);
+							SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaCuentaUsuarioForm.getNombre() + "-Semilla", nuevaCuentaUsuarioForm.getDominio(), null, null, null, null, null);
 							Long idSeed = SemillaDAO.getIdList(c, nuevaCuentaUsuarioForm.getNombre() + "-Semilla", null);
 							nuevaCuentaUsuarioForm.setIdSeed(idSeed);
 							if (nuevaCuentaUsuarioForm.getListaRastreable() != null && !nuevaCuentaUsuarioForm.getListaRastreable().isEmpty()) {
 								// Guardamos la lista Rastreable
 								SemillaDAO.insertList(c, Constants.ID_LISTA_RASTREABLE, nuevaCuentaUsuarioForm.getNombre() + "-Rastreable", nuevaCuentaUsuarioForm.getListaRastreable(), null, null,
-										null, null, null, null);
+										null, null, null);
 								Long idCrawlableList = SemillaDAO.getIdList(c, nuevaCuentaUsuarioForm.getNombre() + "-Rastreable", null);
 								nuevaCuentaUsuarioForm.setIdCrawlableList(idCrawlableList);
 							}
 							if (nuevaCuentaUsuarioForm.getListaNoRastreable() != null && !nuevaCuentaUsuarioForm.getListaNoRastreable().isEmpty()) {
 								// Guardamos la lista No rastreable
 								SemillaDAO.insertList(c, Constants.ID_LISTA_NO_RASTREABLE, nuevaCuentaUsuarioForm.getNombre() + "-NoRastreable", nuevaCuentaUsuarioForm.getListaNoRastreable(), null,
-										null, null, null, null, null);
+										null, null, null, null);
 								Long idNoCrawlableList = SemillaDAO.getIdList(c, nuevaCuentaUsuarioForm.getNombre() + "-NoRastreable", null);
 								nuevaCuentaUsuarioForm.setIdNoCrawlableList(idNoCrawlableList);
 							}

--- a/portal/src/main/java/es/inteco/rastreador2/action/observatorio/SemillasObservatorioAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/observatorio/SemillasObservatorioAction.java
@@ -171,7 +171,7 @@ public class SemillasObservatorioAction extends Action {
 					} else {
 						SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA_OBSERVATORIO, semillaForm.getNombre(),
 								semillaForm.getListaUrlsString(), semillaForm.getCategoria().getId(), null, null,null,
-								semillaForm.getAcronimo(), null, semillaForm.isActiva(), semillaForm.isInDirectory());
+								semillaForm.getAcronimo(), semillaForm.isActiva(), semillaForm.isInDirectory());
 						ActionUtils.setSuccesActionAttributes(request, "mensaje.exito.semilla.creada",
 								"volver.listado.semillas.observatorio");
 						return mapping.findForward(Constants.EXITO2);

--- a/portal/src/main/java/es/inteco/rastreador2/action/rastreo/InsertarRastreoAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/rastreo/InsertarRastreoAction.java
@@ -131,14 +131,14 @@ public class InsertarRastreoAction extends Action {
 
                             if (insertarRastreoForm.getListaRastreable() != null && !insertarRastreoForm.getListaRastreable().isEmpty()) {
                                 //Guardamos la lista Rastreable
-                                SemillaDAO.insertList(c, Constants.ID_LISTA_RASTREABLE, insertarRastreoForm.getCodigo() + "-Rastreable", insertarRastreoForm.getListaRastreable(), null, null, null, null, null, null);
+                                SemillaDAO.insertList(c, Constants.ID_LISTA_RASTREABLE, insertarRastreoForm.getCodigo() + "-Rastreable", insertarRastreoForm.getListaRastreable(), null, null, null, null, null);
                                 Long idCrawlableList = SemillaDAO.getIdList(c, insertarRastreoForm.getCodigo() + "-Rastreable", null);
                                 insertarRastreoForm.setId_lista_rastreable(idCrawlableList);
                             }
 
                             if (insertarRastreoForm.getListaNoRastreable() != null && !insertarRastreoForm.getListaNoRastreable().isEmpty()) {
                                 //Guardamos la lista No rastreable
-                                SemillaDAO.insertList(c, Constants.ID_LISTA_NO_RASTREABLE, insertarRastreoForm.getCodigo() + "-NoRastreable", insertarRastreoForm.getListaNoRastreable(), null, null, null, null, null, null);
+                                SemillaDAO.insertList(c, Constants.ID_LISTA_NO_RASTREABLE, insertarRastreoForm.getCodigo() + "-NoRastreable", insertarRastreoForm.getListaNoRastreable(), null, null, null, null, null);
                                 Long idNoCrawlableList = SemillaDAO.getIdList(c, insertarRastreoForm.getCodigo() + "-NoRastreable", null);
                                 insertarRastreoForm.setId_lista_no_rastreable(idNoCrawlableList);
                             }

--- a/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaGoogleAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaGoogleAction.java
@@ -93,7 +93,7 @@ public class NuevaSemillaGoogleAction extends Action {
                             }
                         }
                     }
-                    SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaGoogleForm.getNombreSemilla(), listaUrls, nuevaSemillaGoogleForm.getCategoria().getId(),  null, null, null, null, null);
+                    SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaGoogleForm.getNombreSemilla(), listaUrls, nuevaSemillaGoogleForm.getCategoria().getId(),  null, null, null, null);
 
                     ActionUtils.setSuccesActionAttributes(request, "mensaje.exito.semilla.generada", "volver.nueva.semilla.google");
                     return mapping.findForward(Constants.EXITO);

--- a/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaIpAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaIpAction.java
@@ -120,7 +120,7 @@ public class NuevaSemillaIpAction extends Action {
                     String listaUrls = "";
                     listaUrls = GeneraRango.getRango(arrayPuertos, ip1, ip2, listaUrls);
 
-                    SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaIpForm.getNombreSemilla(), listaUrls, nuevaSemillaIpForm.getCategoria().getId(), null, null, null, null, null);
+                    SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaIpForm.getNombreSemilla(), listaUrls, nuevaSemillaIpForm.getCategoria().getId(), null, null, null, null);
 
                     ActionUtils.setSuccesActionAttributes(request, "mensaje.exito.semilla.generada", "volver.nueva.semilla.ip");
                     return mapping.findForward(Constants.EXITO);

--- a/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaWebsAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/semillas/NuevaSemillaWebsAction.java
@@ -62,7 +62,7 @@ public class NuevaSemillaWebsAction extends Action {
                             return mapping.findForward(Constants.NUEVA_SEMILLA_FORWARD);
                         }
 
-                        SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaWebsForm.getNombreSemilla(), SeedUtils.getSeedUrlsForDatabase(validUrls), nuevaSemillaWebsForm.getCategoria().getId(), null, null, null, null, null);
+                        SemillaDAO.insertList(c, Constants.ID_LISTA_SEMILLA, nuevaSemillaWebsForm.getNombreSemilla(), SeedUtils.getSeedUrlsForDatabase(validUrls), nuevaSemillaWebsForm.getCategoria().getId(), null, null, null, null);
 
                         ActionUtils.setSuccesActionAttributes(request, "mensaje.exito.semilla.generada", "volver.listado.semillas");
                         return mapping.findForward(Constants.EXITO);

--- a/portal/src/main/java/es/inteco/rastreador2/action/semillas/SeedCategoriesAction.java
+++ b/portal/src/main/java/es/inteco/rastreador2/action/semillas/SeedCategoriesAction.java
@@ -532,7 +532,7 @@ public class SeedCategoriesAction extends Action {
 			try (Connection c = DataBaseManager.getConnection()) {
 				semillaForm.setListaUrlsString(semillaForm.getListaUrlsString().replace("\r\n", ";"));
 				final Long idSeed = SemillaDAO.insertList(c, 4, semillaForm.getNombre(), semillaForm.getListaUrlsString(), semillaForm.getCategoria().getId(), null, null, null,
-						semillaForm.getAcronimo(), null);
+						semillaForm.getAcronimo());
 				final List<ObservatorioForm> observatoryIds = ObservatorioDAO.getObservatoriesFromCategory(c, semillaForm.getCategoria().getId());
 				for (ObservatorioForm observatorioForm : observatoryIds) {
 					if (observatorioForm.getCategoria() != null && Arrays.asList(observatorioForm.getCategoria()).contains(semillaForm.getCategoria().getId())) {

--- a/portal/src/main/java/es/inteco/rastreador2/dao/semilla/SemillaDAO.java
+++ b/portal/src/main/java/es/inteco/rastreador2/dao/semilla/SemillaDAO.java
@@ -164,13 +164,11 @@ public final class SemillaDAO {
 	 * @param complejidad   the complejidad
 	 * @param etiquetas     the etiquetas
 	 * @param acronimo      the acronimo
-	 * @param dependencia   the dependencia
 	 * @return the long
 	 * @throws Exception the exception
 	 */
-	public static Long insertList(Connection c, long tipoLista, String nombreSemilla, String listaUrls, String categoria, String ambito, String complejidad, String etiquetas, String acronimo,
-			String dependencia) throws Exception {
-		return insertList(c, tipoLista, nombreSemilla, listaUrls, categoria, ambito, complejidad, etiquetas, acronimo, dependencia, true, false);
+	public static Long insertList(Connection c, long tipoLista, String nombreSemilla, String listaUrls, String categoria, String ambito, String complejidad, String etiquetas, String acronimo) throws Exception {
+		return insertList(c, tipoLista, nombreSemilla, listaUrls, categoria, ambito, complejidad, etiquetas, acronimo, true, false);
 	}
 
 	/**
@@ -185,16 +183,15 @@ public final class SemillaDAO {
 	 * @param complejidad   the complejidad
 	 * @param etiquetas     the etiquetas
 	 * @param acronimo      the acronimo
-	 * @param dependencia   the dependencia
 	 * @param activa        the activa
 	 * @param inDirectory   the in directory
 	 * @return the long
 	 * @throws SQLException the SQL exception
 	 */
 	public static Long insertList(Connection c, long tipoLista, String nombreSemilla, String listaUrls, String categoria, String ambito, String complejidad, String etiquetas, String acronimo,
-			String dependencia, boolean activa, boolean inDirectory) throws SQLException {
+			boolean activa, boolean inDirectory) throws SQLException {
 		try (PreparedStatement ps = c.prepareStatement(
-				"INSERT INTO lista (id_tipo_lista, nombre, lista, id_categoria, id_ambito, id_complejidad, acronimo, dependencia, activa, in_directory) VALUES (?,?,?,?,?,?,?,?,?,?)",
+				"INSERT INTO lista (id_tipo_lista, nombre, lista, id_categoria, id_ambito, id_complejidad, acronimo, activa, in_directory) VALUES (?,?,?,?,?,?,?,?,?)",
 				Statement.RETURN_GENERATED_KEYS)) {
 			ps.setLong(1, tipoLista);
 			ps.setString(2, nombreSemilla);
@@ -219,13 +216,8 @@ public final class SemillaDAO {
 			} else {
 				ps.setString(7, null);
 			}
-			if (StringUtils.isNotEmpty(dependencia)) {
-				ps.setString(8, dependencia);
-			} else {
-				ps.setString(8, null);
-			}
-			ps.setBoolean(9, activa);
-			ps.setBoolean(10, inDirectory);
+			ps.setBoolean(8, activa);
+			ps.setBoolean(9, inDirectory);
 			ps.executeUpdate();
 			try (ResultSet rs = ps.getGeneratedKeys()) {
 				if (rs.next()) {
@@ -1420,7 +1412,7 @@ public final class SemillaDAO {
 		if (updateListDataForm.getListaRastreable() != null && !updateListDataForm.getListaRastreable().isEmpty()) {
 			if (updateListDataForm.getIdListaRastreable() == 0) {
 				// Guardamos la lista Rastreable
-				insertList(c, Constants.ID_LISTA_RASTREABLE, updateListDataForm.getNombre() + "-Rastreable", updateListDataForm.getListaRastreable(), null, null, null, null, null, null);
+				insertList(c, Constants.ID_LISTA_RASTREABLE, updateListDataForm.getNombre() + "-Rastreable", updateListDataForm.getListaRastreable(), null, null, null, null, null);
 				final long idCrawlableList = SemillaDAO.getIdList(c, updateListDataForm.getNombre() + "-Rastreable", null);
 				updateListDataForm.setIdListaRastreable(idCrawlableList);
 			} else {
@@ -1436,7 +1428,7 @@ public final class SemillaDAO {
 		if (updateListDataForm.getListaNoRastreable() != null && !updateListDataForm.getListaNoRastreable().isEmpty()) {
 			if (updateListDataForm.getIdListaNoRastreable() == 0) {
 				// Guardamos la lista no Rastreable
-				insertList(c, Constants.ID_LISTA_NO_RASTREABLE, updateListDataForm.getNombre() + "-NoRastreable", updateListDataForm.getListaNoRastreable(), null, null, null, null, null, null);
+				insertList(c, Constants.ID_LISTA_NO_RASTREABLE, updateListDataForm.getNombre() + "-NoRastreable", updateListDataForm.getListaNoRastreable(), null, null, null, null, null);
 				Long idNoCrawlableList = SemillaDAO.getIdList(c, updateListDataForm.getNombre() + "-NoRastreable", null);
 				updateListDataForm.setIdListaNoRastreable(idNoCrawlableList);
 			} else {


### PR DESCRIPTION
* Trying to call SemillaDAO.insertList failed because the insert
  statement referenced a non existing column. All call sites invoking
  this function was passing null for the corresponding value though
  (dependencia), so this patch simply removes that parameter and fixes
  the SQL statement.
* The export function in ExportObservatoryDDBB also references this
  column, but that code has not been tested with this patch.