### PR TITLE
include jboss repository to download the jms dependencies

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -74,6 +74,14 @@
 
 	</build>
 
+        <repositories>
+            <repository>
+              <id>repository.jboss.org-public</id>
+              <name>JBoss.org Maven repository</name>
+              <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            </repository>
+        </repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>es.minhap.oaw</groupId>


### PR DESCRIPTION
Incluyendo el repositorio de JBoss, no se requiere la instalación manual de las dependencias jms y javax.transaction tal y como está documentado.

Referencia aquí: https://stackoverflow.com/questions/4908651/the-following-artifacts-could-not-be-resolved-javax-jmsjmsjar1-1