### PR TITLE
Update ObservatorioDAO.java

### DIFF
--- a/portal/src/main/java/es/inteco/rastreador2/dao/observatorio/ObservatorioDAO.java
+++ b/portal/src/main/java/es/inteco/rastreador2/dao/observatorio/ObservatorioDAO.java
@@ -1962,6 +1962,7 @@ public final class ObservatorioDAO {
 					insertarRastreoForm.setNormaAnalisis(String.valueOf(observatorioForm.getCartucho().getId()));
 					final Long idCrawler = ObservatorioDAO.existObservatoryCrawl(c, idObservatory, semillaForm.getId());
 					if (idCrawler == -1) {
+						insertarRastreoForm.setLenguaje(observatorioForm.getLenguaje());
 						insertarRastreoForm.setActive(semillaForm.isActiva());
 						RastreoDAO.insertarRastreo(c, insertarRastreoForm, true);
 						// Desactivamos si la semilla está desactivada o borrada


### PR DESCRIPTION
Without this fix, the select statement in portal\src\main\java\es\inteco\rastreador2\dao\cuentausuario\CuentaUsuarioDAO.java at line 91 will return zero hits, since the rastreo table in the database is missing a value in column id_language