### PR TITLE
Update Maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Currently OAW is deployment under this configuration:
 * Apache Tomcat 7
 * MySQL 5
 
-This is a Maven projet that requieres version 3.0.0 or high
+This is a Maven project that requieres version 3.2.3 or high.
 
 
 ### Instalation


### PR DESCRIPTION
Maven version >= 3.2.3 needed in order to access maven central repositories by HTTPS