### PR TITLE
Fix xml wrong tags

### DIFF
--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -22,7 +22,7 @@
     
     <properties>
 		     <oaw.version>5.6.0</oaw.version>
-    </parent>
+    </properties>
     
 	<build>
 		<resources>


### PR DESCRIPTION
Hi!

When I'm trying to build the Docker Image and install OAW, I'm getting the next error:

Non-parseable POM /oaw/crawler/pom.xml: end tag name must match start tag name from line 23

I noticed that in version 5.6.0 the tag "" are not matching with the tag at this file:

https://github.com/ctt-gob-es/oaw/blob/master/crawler/pom.xml

I think it should be fixed. Thank you!